### PR TITLE
Fix countdown end localization

### DIFF
--- a/index.html
+++ b/index.html
@@ -678,7 +678,8 @@ function updateCountdown() {
         flipTimeValue('hours', '0');
         flipTimeValue('minutes', '0');
         flipTimeValue('seconds', '0');
-        document.getElementById('countdown-label').textContent = '高考已开始！';
+        const lang = translations[currentLang] || translations['zh-CN'];
+        document.getElementById('countdown-label').textContent = lang.examStarted;
     }
 }
 

--- a/js/lang.js
+++ b/js/lang.js
@@ -16,7 +16,8 @@ const translations = {
     days: '天',
     hours: '小时', 
     minutes: '分钟',
-    seconds: '秒'
+    seconds: '秒',
+    examStarted: '高考已开始！'
   },
   'en': {
     title: 'Gaokao Success - Fight for Your Dreams',
@@ -33,7 +34,8 @@ const translations = {
     examDate: 'June 7, 2025 8:00 AM',
     days: 'Days',
     hours: 'Hours',
-    minutes: 'Minutes', 
-    seconds: 'Seconds'
+    minutes: 'Minutes',
+    seconds: 'Seconds',
+    examStarted: 'Gaokao has begun!'
   }
-}; 
+};


### PR DESCRIPTION
## Summary
- add `examStarted` message in English and Chinese to `lang.js`
- use the new localized message in `index.html` countdown

## Testing
- `node -e "require('./js/lang.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_b_683964c6951c8320b35c2cdf21d712a9